### PR TITLE
Wrong name of url name 'payment'

### DIFF
--- a/src/swish.coffee
+++ b/src/swish.coffee
@@ -53,7 +53,7 @@ exports.add = (data) ->
     # Request options (merged with certificates)
     options = R.merge config.cert,
       method: 'post'
-      url: urls.payments
+      url: urls.payment
       body: R.merge config.data, data
       json: true
 


### PR DESCRIPTION
I tried to use the lib but got 'Error: options.uri is a required argument', it turns out there is a bug in the code. Also the documentation is wrong, I'm sending another pull request for that.
